### PR TITLE
feat: add a way to disable metrics server

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,10 +1,11 @@
 apiVersion: v2
 name: betterstack-logs
-version: 1.0.0
+version: 1.1.0
 dependencies:
   - name: metrics-server
     version: '>=0'
     repository: https://kubernetes-sigs.github.io/metrics-server/
+    condition: metrics-server.enabled
   - name: vector
     version: '>=0'
     repository: https://helm.vector.dev

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,6 @@
+metrics-server:
+  enabled: true
+
 vector:
   role: Agent
   service:


### PR DESCRIPTION
Metrics server is already installed on my cluster.
This PR allow me to disable its installation via the betterstack logs chart