### PR TITLE
L-895 Add E2E test workflow for Helm logs and metrics

### DIFF
--- a/.github/helm-values-template.yaml
+++ b/.github/helm-values-template.yaml
@@ -1,3 +1,4 @@
+# config for Minikube with disabled TLS
 vector:
   customConfig:
     sinks:
@@ -7,3 +8,16 @@ vector:
       better_stack_http_metrics_sink:
         auth:
           token: $SOURCE_TOKEN
+    sources:
+      better_stack_kubernetes_metrics_nodes:
+        tls:
+          verify_certificate: false
+          verify_hostname: false
+      better_stack_kubernetes_metrics_pods:
+        tls:
+          verify_certificate: false
+          verify_hostname: false
+
+metrics-server:
+  args:
+    - --kubelet-insecure-tls

--- a/.github/helm-values-template.yaml
+++ b/.github/helm-values-template.yaml
@@ -1,0 +1,9 @@
+vector:
+  customConfig:
+    sinks:
+      better_stack_http_sink:
+        auth:
+          token: $SOURCE_TOKEN
+      better_stack_http_metrics_sink:
+        auth:
+          token: $SOURCE_TOKEN

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,3 +13,8 @@ jobs:
         uses: medyagh/setup-minikube@master
       - name: Try the cluster !
         run: kubectl get pods -A
+      - name: Copy helm-values-template.yaml with SOURCE_TOKEN
+        run: sed 's/$SOURCE_TOKEN/${{ secrets.HELM_E2E_TEST_SOURCE_TOKEN }}/g' .github/helm-values-template.yaml > values.yaml
+      - name: DEBUG
+        run: cat values.yaml
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,15 @@
+name: Release
+
+on:
+  push:
+
+jobs:
+  test-last-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Minikube
+        uses: medyagh/setup-minikube@master
+      - name: Try the cluster !
+        run: kubectl get pods -A

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,12 +9,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Minikube
         uses: medyagh/setup-minikube@master
-      - name: Try the cluster !
+      - name: Check cluster pods
         run: kubectl get pods -A
-      - name: Copy helm-values-template.yaml with SOURCE_TOKEN
+      - name: 1. Add Helm repository
+        run: helm repo add betterstack-logs https://betterstackhq.github.io/logs-helm-chart && helm repo update
+      - name: 2. Set up Helm chart
         run: sed 's/$SOURCE_TOKEN/${{ secrets.HELM_E2E_TEST_SOURCE_TOKEN }}/g' .github/helm-values-template.yaml > values.yaml
-      - name: DEBUG
-        run: cat values.yaml
+      - name: 3. Deploy the chart
+        run: helm install betterstack-logs betterstack-logs/betterstack-logs -f values.yaml
+      - name: Check cluster pods
+        run: kubectl get pods -A
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,11 @@ name: End-to-end test
 
 on:
   push:
+    paths:
+      - .github/**
+  schedule:
+    - cron: '30 */6 * * *'
+  workflow_dispatch:
 
 jobs:
   test-last-release:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,14 +17,24 @@ jobs:
         uses: medyagh/setup-minikube@master
       - name: Check cluster pods
         run: kubectl get pods -A
+
       - name: 1. Add Helm repository
         run: helm repo add betterstack-logs https://betterstackhq.github.io/logs-helm-chart && helm repo update
       - name: 2. Set up Helm chart
         run: sed 's/$SOURCE_TOKEN/${{ secrets.HELM_E2E_TEST_SOURCE_TOKEN }}/g' .github/helm-values-template.yaml > values.yaml
       - name: 3. Deploy the chart
         run: helm install betterstack-logs betterstack-logs/betterstack-logs -f values.yaml
+
       - name: Wait for the chart to be ready
         run: kubectl wait --for=condition=available deployment/betterstack-logs-metrics-server --timeout=60s
       - name: Check cluster pods
         run: kubectl get pods -A
+
+      - name: Deploy Hello World pod
+        run: kubectl run hello-world --image=hello-world --wait
+      - name: Check cluster pods
+        run: kubectl get pods -A
+
+      - name: Wait for a while with the running pods
+        run: sleep 30
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: End-to-end test
 
 on:
   push:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,8 @@ jobs:
         run: sed 's/$SOURCE_TOKEN/${{ secrets.HELM_E2E_TEST_SOURCE_TOKEN }}/g' .github/helm-values-template.yaml > values.yaml
       - name: 3. Deploy the chart
         run: helm install betterstack-logs betterstack-logs/betterstack-logs -f values.yaml
+      - name: Wait for the chart to be ready
+        run: kubectl wait --for=condition=available deployment/betterstack-logs-metrics-server --timeout=60s
       - name: Check cluster pods
         run: kubectl get pods -A
 


### PR DESCRIPTION
Installs Minikube and Helm, integrates Logs [as described in our docs](https://betterstack.com/docs/logs/kubernetes/) and runs a `hello-world` pod. Then I created two new charts in our E2E dashboard:

<img width="781" alt="image" src="https://github.com/BetterStackHQ/logs-helm-chart/assets/10008612/8d60e46d-f60c-4b51-a846-ade28594d926">

So we can set up alerts tomorrow after we have a bit more data.