### PR TITLE
Update test.yaml: Wait for a full minute with the running pods

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,5 +41,5 @@ jobs:
         run: kubectl get pods -A
 
       - name: Wait for a while with the running pods
-        run: sleep 30
+        run: sleep 60
 


### PR DESCRIPTION
Let's try giving the freshly run cluster a bit more time to collect and export logs and metrics to avoid false negative results.

The Helm E2E tests will also stop running after a long period of inactivity of the repo. Maybe we could move the workflow to one of our internal repos. WDYT?