### PR TITLE
Improve E2E test with debugging and checking running pods

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Wait for a while with the running pods
         run: sleep 60
+      - name: Check cluster pods
+        run: kubectl get pods -A
 
       - name: Show logs from Vector pod for debugging
         run: kubectl logs -l app.kubernetes.io/name=vector

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,3 +46,9 @@ jobs:
       - name: Wait for a while with the running pods
         run: sleep 60
 
+      - name: Show logs from Vector pod for debugging
+        run: kubectl logs -l app.kubernetes.io/name=vector
+
+      - name: Check if all pods are running
+        run: kubectl get pods -A -o jsonpath='{range .items[*]}{.status.phase}{"\n"}{end}' | grep -qv "^Running$" && echo "Not all pods are running" && exit 1 || echo "OK"
+


### PR DESCRIPTION
I've noticed the issue in `v1.1.4` wasn't reported by [our workflow](https://github.com/BetterStackHQ/logs-helm-chart/actions/runs/12672687549/job/35317274869) even though the Vector pod err'd

```
> Run kubectl get pods -A
NAMESPACE     NAME                                              READY   STATUS    RESTARTS      AGE
default       betterstack-logs-metrics-server-7f77b958c-mnwh9   1/1     Running   0             30s
default       betterstack-logs-vector-s6sjn                     0/1     Error     2 (23s ago)   30s
kube-system   coredns-6f6b679f8f-pfzl7                          1/1     Running   0             72s
kube-system   etcd-minikube                                     1/1     Running   0             78s
kube-system   kube-apiserver-minikube                           1/1     Running   0             78s
kube-system   kube-controller-manager-minikube                  1/1     Running   0             78s
kube-system   kube-proxy-bdjp8                                  1/1     Running   0             73s
kube-system   kube-scheduler-minikube                           1/1     Running   0             78s
kube-system   storage-provisioner                               1/1     Running   0             72s
```

Let's make it a bit easier to debug 🙏 