### PR TITLE
SH-1002 [CI] Update GitHub Actions versions

### DIFF
--- a/.github/workflows/reindex.yaml
+++ b/.github/workflows/reindex.yaml
@@ -32,4 +32,4 @@ jobs:
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Ensure that chart version in YAML is the same as release tag
         run: |
           sed -i "s/^version: .*/version: ${GITHUB_REF#refs\/tags\/v}/" Chart.yaml
           git diff --exit-code
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update chart dependencies
@@ -27,6 +27,6 @@ jobs:
       - name: Package chart
         run: helm package .
       - name: Create a release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: '*.tgz'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Minikube


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions (forced to Node 24 since June 2nd, 2026; Node 20 removed from runners on September 16th, 2026), and Node 12/16 actions are already force-migrated. This bumps the affected actions to their latest majors (all Node 24):

- `actions/checkout` `v4` → `v7`
- `actions/deploy-pages` `v4` → `v5`
- `azure/setup-helm` `v4` → `v5`
- `softprops/action-gh-release` `v2` → `v3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
